### PR TITLE
Render all of the photos in the gallery view

### DIFF
--- a/Devlog.md
+++ b/Devlog.md
@@ -1,5 +1,21 @@
 # Dev Log
 
+### 2022-05-09
+- TODO: Update filepaths to only store the filepath relative to the selected directory
+  - Append the directory to the photo filepath when you need to access the image
+  - This way the directory can be moved without causing issues with the data
+- Image orientation:
+  - metadata.Image.Orientation
+    - https://piexifjs.readthedocs.io/en/latest/sample.html
+- Installed and used [image-size](https://www.npmjs.com/package/image-size) package to images missing metadata
+
+### 2022-05-08
+- Added reading/writing from a file
+- Next:
+  - Figure out gallery view
+  - Figure out what user data to collect
+  - Add UI to display and collect metadata and annotations
+  - Update each photo for changes to data UI
 ### 2022-05-05
 - Trying to get photo metadata with [piexifjs](https://github.com/hMatoba/piexifjs)
   - based on this [article](https://auth0.com/blog/read-edit-exif-metadata-in-photos-with-javascript/#The--Piexifjs--Library)
@@ -20,6 +36,8 @@ Proposed dev sequence
 
 What do I want this app to do?
 - Display images
+  - handle rotating images if annotated as such
+  - alt text from photo description?
 - Annotate photos with:
   - Date
     - Created

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "electron-updater": "^4.6.5",
         "gestalt": "^52.1.0",
         "history": "^5.3.0",
+        "image-size": "^1.0.1",
         "piexifjs": "^1.0.6",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -9050,6 +9051,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz",
+      "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -9164,8 +9179,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -13232,6 +13246,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -23328,6 +23350,14 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "image-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz",
+      "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
+      "requires": {
+        "queue": "6.0.2"
+      }
+    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -23414,8 +23444,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -26405,6 +26434,14 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
       "dev": true
+    },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "requires": {
+        "inherits": "~2.0.3"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "electron-updater": "^4.6.5",
     "gestalt": "^52.1.0",
     "history": "^5.3.0",
+    "image-size": "^1.0.1",
     "piexifjs": "^1.0.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/src/DataManager/DataManager.ts
+++ b/src/DataManager/DataManager.ts
@@ -1,8 +1,8 @@
-import { PhotoData } from './PhotoManager/Photo';
+import Photo from './PhotoManager/Photo';
 import PhotoManager from './PhotoManager/PhotoManager';
 
 interface InitialData {
-  photos: PhotoData[];
+  photos: Photo[];
 }
 
 export default class DataManager {

--- a/src/DataManager/PhotoManager/PhotoManager.ts
+++ b/src/DataManager/PhotoManager/PhotoManager.ts
@@ -1,15 +1,9 @@
-import Photo, { PhotoData } from './Photo';
+import Photo from './Photo';
 
 export default class PhotoManager {
   photos: Photo[] = [];
 
-  initialize({
-    data,
-    imagePaths,
-  }: {
-    data: PhotoData[];
-    imagePaths: string[];
-  }) {
+  initialize({ data, imagePaths }: { data: Photo[]; imagePaths: string[] }) {
     const existingPhotoFilepaths = data.map((itm) => itm.filePath);
 
     const newPhotos = imagePaths.filter(

--- a/src/DataManager/PhotoManager/parseExif.ts
+++ b/src/DataManager/PhotoManager/parseExif.ts
@@ -75,15 +75,27 @@ interface RawPiexif {
 }
 
 export interface Metadata {
-  Image: Record<string, any> | null;
-  GPS: Record<string, any> | null;
-  Exif: Record<string, any> | null;
+  Image: Record<string, any>;
+  GPS: Record<string, any>;
+  Exif: {
+    PixelXDimension: number | null | undefined;
+    PixelYDimension: number | null | undefined;
+  };
 }
+
+export const defaultMetadata = {
+  Image: {},
+  GPS: {},
+  Exif: {
+    PixelXDimension: null,
+    PixelYDimension: null,
+  },
+};
 
 export default function parseExif(binaryFileContent: string): Metadata {
   const rawExifData: RawPiexif = piexif.load(binaryFileContent);
 
-  const output = { Image: null, GPS: null, Exif: null };
+  const output = { ...defaultMetadata };
 
   Object.entries(rawExifData).forEach((topLevelData) => {
     const topLevelAttr = topLevelData[0];

--- a/src/renderer/Gallery.tsx
+++ b/src/renderer/Gallery.tsx
@@ -1,24 +1,33 @@
-import { Box, Image } from 'gestalt';
+import { Image, Mask, Masonry } from 'gestalt';
 import Photo from '../DataManager/PhotoManager/Photo';
 
 interface Props {
   photos: Photo[];
 }
 
-export default function Gallery({ photos }: Props) {
-  const photo = photos[2];
-
-  console.log(photo);
+function PhotoRep({
+  data,
+}: {
+  data: Photo;
+  // itemIdx: number;
+  // isMeasuring: boolean;
+}) {
+  const { PixelXDimension, PixelYDimension } = data.metadata.Exif;
+  // TODO: Set alt text based on user description
 
   return (
-    <Box color="red" height="100vh">
+    <Mask rounding={4}>
       <Image
         color="transparent"
         alt="TODO"
-        naturalHeight={500}
-        naturalWidth={500}
-        src={`data:image/jpg;base64,${photo.base64}`}
+        naturalHeight={PixelYDimension || 500}
+        naturalWidth={PixelXDimension || 500}
+        src={`data:image/jpg;base64,${data.base64}`}
       />
-    </Box>
+    </Mask>
   );
+}
+
+export default function Gallery({ photos }: Props) {
+  return <Masonry comp={PhotoRep} items={photos} />;
 }


### PR DESCRIPTION
Use Gestalt Masonry to render all of the images to the gallery view
Use 'image-size' package to get the image height/width if that data is not available in the image metadata.  Image height/width is necessary to ensure that the image renders at the best size within Masonry.
